### PR TITLE
Use numeric instead of number in random_password resource

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.50.0
+  rev: v1.74.1
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
+      args:
+      - --args=--anchor=false
+      - --args=--html=false
+      - --args=--hide=modules
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v3.4.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
-- repo: git://github.com/antonbabenko/pre-commit-terraform
+- repo: https://github.com/antonbabenko/pre-commit-terraform
   rev: v1.50.0
   hooks:
     - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ module "random_password" {
 | aws | n/a |
 | random | >= 2.2.0 |
 
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_metric_filter.secret_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
+| [aws_cloudwatch_metric_alarm.unauthorized_cloudtrail_calls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_secretsmanager_secret.secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.secret_val](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [random_password.random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -64,7 +74,6 @@ module "random_password" {
 | secret | Generated secret |
 | secret\_arn | The ARN of the secret |
 | version\_id | The unique identifier of the version of the secret. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Warning

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ module "random_password" {
 | name\_prefix | Name Prefix (not used if name specified) | `string` | `"terraform"` | no |
 | override\_special | n/a | `string` | `""` | no |
 | pass\_version | Password version. Increment this to trigger a new password. | `number` | `1` | no |
-| recovery_window_in_days | Number of days to wait before deleting the secret | `number` | `"30"` | no |
+| recovery\_window\_in\_days | Number of days that AWS Secrets Manager waits before it can delete the secret. | `number` | `30` | no |
 | secret\_access\_metric\_namespace | Metric namespace to use for CloudWatch metric | `string` | `"SecretsManager"` | no |
 | secret\_access\_notification\_arn | SNS topic to notify on secret access (required if `enable_secret_access_notification=true`) | `string` | `""` | no |
 | tags | Tags to add to supported resources | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "random_password" "random_string" {
   count            = var.create_secret ? 1 : 0
   length           = var.length
   lower            = var.use_lower
-  number           = var.use_number
+  numeric          = var.use_number
   min_lower        = var.min_lower
   min_numeric      = var.min_numeric
   min_special      = var.min_special


### PR DESCRIPTION
According to the [documentation](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password#number) the parameter *number* for the resource `random_password` is deprecated and we should use *numeric* instead.

This pull request also takes the liberty of introducing some enhancements/fixes to the pre-commit configuration

Special thanks to [Allane Mobilty Group](https://allane-mobility-group.com/en) for sponsoring work on this